### PR TITLE
Made `User Settings` a separate page. Added slide page transition anims for `PageView` and `BottomNavigationBar`

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:hospital_stay_helper/config/styles.dart';
 import 'package:hospital_stay_helper/localizations/language_constants.dart';
 import 'package:hospital_stay_helper/localizations/localization.dart';
 import 'package:hospital_stay_helper/plugins/firebase_analytics.dart';
@@ -66,7 +67,9 @@ class _AppState extends State<App> {
                   // primarySwatch: Colors.blue,
                   scaffoldBackgroundColor: HexColor(purpleTheme),
                   visualDensity: VisualDensity.adaptivePlatformDensity,
-                  fontFamily: 'Open Sans'),
+                  fontFamily: 'Open Sans',
+                accentColor: Styles.blueTheme, // Mainly for overscroll color (in Android). ie. instead of the default blue
+              ),
               locale: _locale,
               supportedLocales: [
                 Locale("en", "US"),

--- a/lib/config/styles.dart
+++ b/lib/config/styles.dart
@@ -86,7 +86,7 @@ class Styles {
   static const bigImpact =
       TextStyle(fontSize: 60, fontWeight: FontWeight.w500, color: Colors.black);
 
-  static const appBar = TextStyle(fontSize: 22, fontWeight: FontWeight.w800);
+  static const appBar = TextStyle(fontSize: 22, fontWeight: FontWeight.w800, color: Colors.white);
   static const guidelineCard =
       TextStyle(fontSize: 18, fontWeight: FontWeight.w600, color: Colors.white);
   static const hyperlink = TextStyle(

--- a/lib/navigation_bar_controller.dart
+++ b/lib/navigation_bar_controller.dart
@@ -81,8 +81,9 @@ class _AppBottomNavBarControllerState extends State<AppBottomNavBarController> {
                         child: Text("Later")),
                     TextButton(
                         onPressed: () {
-                          openPage(5);
                           Navigator.pop(context);
+                          Navigator.push(context,
+                              MaterialPageRoute(builder: (c) => ProfilePage()));
                         },
                         child: Text("Okay")),
                   ],

--- a/lib/navigation_bar_controller.dart
+++ b/lib/navigation_bar_controller.dart
@@ -15,6 +15,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class AppBottomNavBarController extends StatefulWidget {
   final int currentIndex;
+
   AppBottomNavBarController({Key key, @required this.currentIndex})
       : super(key: key);
 
@@ -28,7 +29,6 @@ class _AppBottomNavBarControllerState extends State<AppBottomNavBarController> {
   List<Widget> pages;
   PageController _pageController;
   int _selectedIndex;
-  bool profileSelected = false;
   bool haveOpenProfile = false;
 
   @override
@@ -48,8 +48,9 @@ class _AppBottomNavBarControllerState extends State<AppBottomNavBarController> {
         openPage: openPage,
       ),
       SearchPage(key: PageStorageKey('searchservices')),
-      ProfilePage(key: PageStorageKey('yourprofile')),
     ];
+
+    // TODO: If page state lost when changing page in bottom nav bar, then try keepPage = True
     _pageController = PageController(initialPage: _selectedIndex);
     profileSelect();
   }
@@ -97,11 +98,17 @@ class _AppBottomNavBarControllerState extends State<AppBottomNavBarController> {
 
   void openPage(int index) async {
     setState(() {
-      if (index < 5)
-        _selectedIndex = index;
-      else
-        profileSelected = true;
-      _pageController.jumpToPage(index);
+      if (0 <= index && index < pages.length) {
+        // _selectedIndex = index;
+        // _pageController.jumpToPage(index);
+
+        _pageController.animateToPage(
+          index,
+          duration: Duration(milliseconds: 800),
+          // Stick with Curves.easeIn or similar to avoid errors (https://github.com/flutter/flutter/issues/47730)
+          curve: Curves.ease,
+        );
+      }
     });
     switch (index) {
       case 0:
@@ -137,16 +144,11 @@ class _AppBottomNavBarControllerState extends State<AppBottomNavBarController> {
             unselectedItemColor: Colors.white,
             backgroundColor: Styles.blueTheme,
             selectedLabelStyle: TextStyle(
-                fontSize: 15,
-                fontWeight: FontWeight.w700,
-                color: Styles.darkPinkTheme),
+                fontWeight: FontWeight.w700, color: Styles.darkPinkTheme),
             onTap: (int index) {
-              setState(() {
-                _selectedIndex = index;
-                profileSelected = false;
-                openPage(index);
-              });
-            }, // rebuild this widget
+              setState(() => openPage(index));
+            },
+            // rebuild this widget
             currentIndex: selectedIndex,
             items: const <BottomNavigationBarItem>[
               BottomNavigationBarItem(
@@ -184,7 +186,6 @@ class _AppBottomNavBarControllerState extends State<AppBottomNavBarController> {
     'Find In-Network Hospitals',
     'Search Medical Services'
   ];
-  String profileTitle = 'User Settings';
 
   @override
   Widget build(BuildContext context) {
@@ -192,48 +193,89 @@ class _AppBottomNavBarControllerState extends State<AppBottomNavBarController> {
       appBar: AppBar(
         backgroundColor: Styles.blueTheme,
         actions: [
-          IconButton(
-            color: profileSelected ? Styles.blueTheme : Colors.grey,
-            icon: Badge(
-              position: BadgePosition.topStart(),
-              // badgeColor: Colors.white,
-              showBadge: !haveOpenProfile,
-              badgeContent: Text(
-                "1",
-                style:
-                    TextStyle(color: Colors.white, fontWeight: FontWeight.w700),
-              ),
-              child: ClipOval(
+          Badge(
+            position: BadgePosition.topStart(),
+            // badgeColor: Colors.white,
+            showBadge: !haveOpenProfile,
+            badgeContent: Text(
+              "1",
+              style:
+                  TextStyle(color: Colors.white, fontWeight: FontWeight.w700),
+            ),
+            child: Hero(
+              tag: 'settings_icon',
+
+              // Not doing the flightShuttleBuilder approach to have the left arrow rotation animation
+              // This is because the duration is too less, so the animation won't even be seen.
+              // Thus, no point in increasing complexity that'll decrease performance
+              // So sticking only with the usual Hero animation (no rotation animation)
+
+              // flightShuttleBuilder: (context, anim, dir, _, __) {
+              //   print(anim.value);
+              //   ColorTween tween = ColorTween(begin: Colors.red, end: Colors.green);
+              //   return Container(width: 20.0 * anim.value, height: 20.0, color: tween.transform(anim.value),);
+              // },
+              // flightShuttleBuilder: (
+              //     BuildContext flightContext,
+              //     Animation<double> animation,
+              //     HeroFlightDirection flightDirection,
+              //     BuildContext fromHeroContext,
+              //     BuildContext toHeroContext,
+              //     ) {
+              //   print(animation.value);
+              //   final Hero toHero = toHeroContext.widget;
+              //   return RotationTransition(
+              //     turns: animation,
+              //     child: toHero.child,
+              //   );
+              // },
+              child: Material(
+                color: Colors.transparent,
                 child: Container(
-                  padding: EdgeInsets.all(5),
-                  color: Colors.white,
-                  child: Icon(
-                    Icons.settings,
+                  width: 48.0,
+                  height: 48.0,
+                  child: Padding(
+                    padding: const EdgeInsets.all(6.0),
+                    child: GestureDetector(
+                      onTap: () => Navigator.push(context,
+                          MaterialPageRoute(builder: (c) => ProfilePage())),
+                      child: Container(
+                        decoration: BoxDecoration(
+                            shape: BoxShape.circle, color: Colors.white),
+                        child: Icon(
+                          Icons.settings,
+                          color: Colors.grey,
+                          size: 24.0,
+                        ),
+                      ),
+                    ),
                   ),
                 ),
               ),
             ),
-            onPressed: () => setState(() {
-              profileSelected = haveOpenProfile = true;
-              _pageController.jumpToPage(5);
-            }),
           ),
         ],
-        title: profileSelected
-            ? Text(
-                profileTitle,
-                style: Styles.appBar,
-              )
-            : Text(
+        title: Hero(
+          tag: 'app_bar_title',
+          child: Container(
+            width: double.infinity,
+            child: Material(
+              color: Colors.transparent,
+              child: Text(
                 _pageTitles[_selectedIndex],
                 style: Styles.appBar,
               ),
+            ),
+          ),
+        ),
       ),
       bottomNavigationBar: _bottomNavBar(_selectedIndex),
       body: PageView(
         controller: _pageController,
-        physics: NeverScrollableScrollPhysics(),
+        // physics: NeverScrollableScrollPhysics(),
+        // physics: BouncingScrollPhysics(),
         children: pages,
+        onPageChanged: (index) => setState(() => _selectedIndex = index),
       ),
     );
   }

--- a/lib/screens/checkHospital.dart
+++ b/lib/screens/checkHospital.dart
@@ -11,6 +11,7 @@ import 'package:hospital_stay_helper/components/pageDescription.dart';
 import 'package:hospital_stay_helper/config/styles.dart';
 import 'package:hospital_stay_helper/components/textIcon.dart';
 import 'package:hospital_stay_helper/plugins/firebase_analytics.dart';
+import 'package:hospital_stay_helper/screens/profilePage.dart';
 import 'package:http/http.dart' as http;
 import 'package:material_floating_search_bar/material_floating_search_bar.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -18,6 +19,7 @@ import '../app.dart';
 
 class HospitalSearchPage extends StatefulWidget {
   final Function openPage;
+
   HospitalSearchPage({Key key, this.openPage}) : super(key: key);
 
   @override
@@ -61,7 +63,8 @@ class _CheckHospitalPage extends State<HospitalSearchPage>
       content: Text("You haven't selected a provider"),
       action: SnackBarAction(
         label: 'SETTINGS',
-        onPressed: () => widget.openPage(5),
+        onPressed: () => Navigator.push(
+            context, MaterialPageRoute(builder: (c) => ProfilePage())),
       ),
     ));
   }

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -6,6 +6,7 @@ import 'package:hospital_stay_helper/class/sharePref.dart';
 import 'package:hospital_stay_helper/config/styles.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:hospital_stay_helper/plugins/firebase_analytics.dart';
+import 'package:hospital_stay_helper/screens/profilePage.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -18,9 +19,11 @@ class DashboardPage extends StatefulWidget {
   _DashboardPageState createState() => _DashboardPageState();
 }
 
-class _DashboardPageState extends State<DashboardPage> with AutomaticKeepAliveClientMixin<DashboardPage> {
+class _DashboardPageState extends State<DashboardPage>
+    with AutomaticKeepAliveClientMixin<DashboardPage> {
   String insuranceProvider = '', stateOfResidence = '';
   List<bool> walkthrough = [true, true, true, true, true];
+
   // double amountDeductiblePaid;
 
   // _loadSaved() async {
@@ -450,9 +453,8 @@ class _DashboardPageState extends State<DashboardPage> with AutomaticKeepAliveCl
     // }
 
     return GestureDetector(
-      onTap: () {
-        widget.openPage(5);
-      },
+      onTap: () => Navigator.push(
+          context, MaterialPageRoute(builder: (c) => ProfilePage())),
       child: Container(
         decoration:
             BoxDecoration(shape: BoxShape.circle, color: Styles.modestPink),
@@ -744,7 +746,10 @@ class CustomSliverDelegate extends SliverPersistentHeaderDelegate {
                       child: Row(
                         children: [
                           GestureDetector(
-                            onTap: () => openPage(5),
+                            onTap: () => Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (c) => ProfilePage())),
                             child: Column(
                                 mainAxisAlignment: MainAxisAlignment.start,
                                 crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/dashboard.dart
+++ b/lib/screens/dashboard.dart
@@ -18,7 +18,7 @@ class DashboardPage extends StatefulWidget {
   _DashboardPageState createState() => _DashboardPageState();
 }
 
-class _DashboardPageState extends State<DashboardPage> {
+class _DashboardPageState extends State<DashboardPage> with AutomaticKeepAliveClientMixin<DashboardPage> {
   String insuranceProvider = '', stateOfResidence = '';
   List<bool> walkthrough = [true, true, true, true, true];
   // double amountDeductiblePaid;
@@ -485,9 +485,9 @@ class _DashboardPageState extends State<DashboardPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      body: CustomScrollView(
+    return Container(
+      color: Colors.white,
+      child: CustomScrollView(
         slivers: [
           // Header:
           SliverPersistentHeader(
@@ -654,6 +654,9 @@ class _DashboardPageState extends State<DashboardPage> {
       ),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }
 
 /// Small helper ChangeNotifier just to manually trigger a rebuild (when height changes)

--- a/lib/screens/guidelinesPage.dart
+++ b/lib/screens/guidelinesPage.dart
@@ -246,9 +246,9 @@ class RootCategoriesPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        backgroundColor: Styles.shadowWhite,
-        body: SingleChildScrollView(
+    return Container(
+        color: Styles.shadowWhite,
+        child: SingleChildScrollView(
           child: Column(
             // mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[

--- a/lib/screens/profilePage.dart
+++ b/lib/screens/profilePage.dart
@@ -71,33 +71,14 @@ class _ProfilePage extends State<ProfilePage>
       // backgroundColor: Colors.deepPurple[600],
       appBar: AppBar(
         backgroundColor: Styles.blueTheme,
-        // leading: ClipOval(
-        //   child: Container(
-        //     // padding: EdgeInsets.all(5),
-        //     color: Colors.white,
-        //     child: Icon(
-        //       Icons.arrow_back,
-        //       color: Colors.grey,
-        //       size: 24.0,
-        //     ),
-        //   ),
-        // ),
-        // leading: const SizedBox.shrink(),
-        // leadingWidth: 0.0,
         leading: Center(
           child: Hero(
             tag: 'settings_icon',
             child: Material(
               color: Colors.transparent,
               child: Container(
-                // constraints: BoxConstraints(maxWidth: 48.0, maxHeight: 48.0),
                 width: 48.0,
                 height: 48.0,
-                // decoration: BoxDecoration(
-                //   shape: BoxShape.circle,
-                //   color: Colors.white,
-                // ),
-                // color: Colors.green,
                 child: Padding(
                   padding: const EdgeInsets.all(6.0),
                   child: GestureDetector(
@@ -111,23 +92,6 @@ class _ProfilePage extends State<ProfilePage>
                     ),
                   ),
                 ),
-
-                // child: Container(
-                //   decoration: BoxDecoration(
-                //     shape: BoxShape.circle,
-                //     color: Colors.white,
-                //   ),
-                //   child: Center(
-                //     child: Padding(
-                //       padding: const EdgeInsets.all(8.0),
-                //       child: Icon(
-                //         Icons.settings,
-                //         color: Colors.grey,
-                //         size: 24.0,
-                //       ),
-                //     ),
-                //   ),
-                // ),
               ),
             ),
           ),
@@ -146,71 +110,6 @@ class _ProfilePage extends State<ProfilePage>
             ),
           ),
         ),
-
-        // title: Row(
-        //   children: [
-        //     // Hero(
-        //     //   tag: 'settings_icon',
-        //     //   child: Material(
-        //     //     color: Colors.transparent,
-        //     //     child: Container(
-        //     //       // constraints: BoxConstraints(maxWidth: 48.0, maxHeight: 48.0),
-        //     //       width: 48.0,
-        //     //       height: 48.0,
-        //     //       // decoration: BoxDecoration(
-        //     //       //   shape: BoxShape.circle,
-        //     //       //   color: Colors.white,
-        //     //       // ),
-        //     //       // color: Colors.green,
-        //     //       child: Padding(
-        //     //         padding: const EdgeInsets.all(6.0),
-        //     //         child: GestureDetector(
-        //     //           onTap: () => Navigator.pop(context),
-        //     //           child: Container(
-        //     //             decoration: BoxDecoration(
-        //     //                 shape: BoxShape.circle,
-        //     //                 color: Colors.white
-        //     //             ),
-        //     //             child: Icon(Icons.arrow_back, color: Colors.grey, size: 24.0,),
-        //     //           ),
-        //     //         ),
-        //     //       ),
-        //     //
-        //     //       // child: Container(
-        //     //       //   decoration: BoxDecoration(
-        //     //       //     shape: BoxShape.circle,
-        //     //       //     color: Colors.white,
-        //     //       //   ),
-        //     //       //   child: Center(
-        //     //       //     child: Padding(
-        //     //       //       padding: const EdgeInsets.all(8.0),
-        //     //       //       child: Icon(
-        //     //       //         Icons.settings,
-        //     //       //         color: Colors.grey,
-        //     //       //         size: 24.0,
-        //     //       //       ),
-        //     //       //     ),
-        //     //       //   ),
-        //     //       // ),
-        //     //     ),
-        //     //   ),
-        //     // ),
-        //     // const SizedBox(width: 10.0,),
-        //     // Expanded(
-        //     //   child: Hero(
-        //     //     tag: 'app_bar_title',
-        //     //     child: Material(
-        //     //       color: Colors.transparent,
-        //     //       child: Text(
-        //     //         'UserSettings',
-        //     //         style: Styles.appBar,
-        //     //       ),
-        //     //     ),
-        //     //   ),
-        //     // ),
-        //   ],
-        // )
-        // ),
       ),
       body: SingleChildScrollView(
         child: Column(mainAxisAlignment: MainAxisAlignment.start, children: [

--- a/lib/screens/profilePage.dart
+++ b/lib/screens/profilePage.dart
@@ -69,6 +69,149 @@ class _ProfilePage extends State<ProfilePage>
     super.build(context);
     return Scaffold(
       // backgroundColor: Colors.deepPurple[600],
+      appBar: AppBar(
+        backgroundColor: Styles.blueTheme,
+        // leading: ClipOval(
+        //   child: Container(
+        //     // padding: EdgeInsets.all(5),
+        //     color: Colors.white,
+        //     child: Icon(
+        //       Icons.arrow_back,
+        //       color: Colors.grey,
+        //       size: 24.0,
+        //     ),
+        //   ),
+        // ),
+        // leading: const SizedBox.shrink(),
+        // leadingWidth: 0.0,
+        leading: Center(
+          child: Hero(
+            tag: 'settings_icon',
+            child: Material(
+              color: Colors.transparent,
+              child: Container(
+                // constraints: BoxConstraints(maxWidth: 48.0, maxHeight: 48.0),
+                width: 48.0,
+                height: 48.0,
+                // decoration: BoxDecoration(
+                //   shape: BoxShape.circle,
+                //   color: Colors.white,
+                // ),
+                // color: Colors.green,
+                child: Padding(
+                  padding: const EdgeInsets.all(6.0),
+                  child: GestureDetector(
+                    onTap: () => Navigator.pop(context),
+                    child: Container(
+                      decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: Colors.white
+                      ),
+                      child: Icon(Icons.arrow_back, color: Colors.grey, size: 24.0,),
+                    ),
+                  ),
+                ),
+
+                // child: Container(
+                //   decoration: BoxDecoration(
+                //     shape: BoxShape.circle,
+                //     color: Colors.white,
+                //   ),
+                //   child: Center(
+                //     child: Padding(
+                //       padding: const EdgeInsets.all(8.0),
+                //       child: Icon(
+                //         Icons.settings,
+                //         color: Colors.grey,
+                //         size: 24.0,
+                //       ),
+                //     ),
+                //   ),
+                // ),
+              ),
+            ),
+          ),
+        ),
+
+        title: Hero(
+          tag: 'app_bar_title',
+          child: Container(
+            width: double.infinity,
+            child: Material(
+              color: Colors.transparent,
+              child: Text(
+                'User Settings',
+                style: Styles.appBar,
+              ),
+            ),
+          ),
+        ),
+
+        // title: Row(
+        //   children: [
+        //     // Hero(
+        //     //   tag: 'settings_icon',
+        //     //   child: Material(
+        //     //     color: Colors.transparent,
+        //     //     child: Container(
+        //     //       // constraints: BoxConstraints(maxWidth: 48.0, maxHeight: 48.0),
+        //     //       width: 48.0,
+        //     //       height: 48.0,
+        //     //       // decoration: BoxDecoration(
+        //     //       //   shape: BoxShape.circle,
+        //     //       //   color: Colors.white,
+        //     //       // ),
+        //     //       // color: Colors.green,
+        //     //       child: Padding(
+        //     //         padding: const EdgeInsets.all(6.0),
+        //     //         child: GestureDetector(
+        //     //           onTap: () => Navigator.pop(context),
+        //     //           child: Container(
+        //     //             decoration: BoxDecoration(
+        //     //                 shape: BoxShape.circle,
+        //     //                 color: Colors.white
+        //     //             ),
+        //     //             child: Icon(Icons.arrow_back, color: Colors.grey, size: 24.0,),
+        //     //           ),
+        //     //         ),
+        //     //       ),
+        //     //
+        //     //       // child: Container(
+        //     //       //   decoration: BoxDecoration(
+        //     //       //     shape: BoxShape.circle,
+        //     //       //     color: Colors.white,
+        //     //       //   ),
+        //     //       //   child: Center(
+        //     //       //     child: Padding(
+        //     //       //       padding: const EdgeInsets.all(8.0),
+        //     //       //       child: Icon(
+        //     //       //         Icons.settings,
+        //     //       //         color: Colors.grey,
+        //     //       //         size: 24.0,
+        //     //       //       ),
+        //     //       //     ),
+        //     //       //   ),
+        //     //       // ),
+        //     //     ),
+        //     //   ),
+        //     // ),
+        //     // const SizedBox(width: 10.0,),
+        //     // Expanded(
+        //     //   child: Hero(
+        //     //     tag: 'app_bar_title',
+        //     //     child: Material(
+        //     //       color: Colors.transparent,
+        //     //       child: Text(
+        //     //         'UserSettings',
+        //     //         style: Styles.appBar,
+        //     //       ),
+        //     //     ),
+        //     //   ),
+        //     // ),
+        //   ],
+        // )
+        // ),
+      ),
       body: SingleChildScrollView(
         child: Column(mainAxisAlignment: MainAxisAlignment.start, children: [
           // Padding(padding: EdgeInsets.symmetric(horizontal: 20, vertical: 5)),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   badges:
     dependency: "direct main"
     description:
@@ -508,7 +508,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -543,7 +543,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
1. `UserSettings` (`ProfilePage`) is now a separate page. ie. it is no longer a part of the `BottomNavigationBar` or `PageView`. So to open `UserSettings`, we need to click the gear on the top right.
2. Animated GearIcon and AppBar title

<table>
  <tr>
    <th>Clicking settings icon</th>
    <th>From AlertDialog</th>
  </tr>
  <tr>
    <td><img width="200px" src="https://user-images.githubusercontent.com/45748283/126486883-775e0cb4-36a5-43d5-b955-3c1fd1d5a57b.gif"></td>
    <td><img width="200px" src="https://user-images.githubusercontent.com/45748283/126487226-2168cc83-633e-4137-a596-8fe394438832.gif"></td>
  </tr>
</table>

3. PageView is scrollable

<table>
  <tr>
    <th>Using Scroll</th>
    <th>Using BottomNavigationBar</th>
  </tr>
  <tr>
    <td><img width="200px" src="https://user-images.githubusercontent.com/45748283/126490944-6884be91-316e-4f9b-810f-3d24c98243bb.gif"></td>
    <td><img width="200px" src="https://user-images.githubusercontent.com/45748283/126490922-243f9120-e554-4fde-bccd-1e53a1244787.gif"></td>
  </tr>
</table>